### PR TITLE
City data

### DIFF
--- a/australien/perth/index.md
+++ b/australien/perth/index.md
@@ -9,7 +9,11 @@ Perth, eine der isoliertesten Großstädte der Welt, überrascht mit wunderschö
 
 ## 🏨 Unterkunft
 
-_Wird noch ergänzt..._
+[Mullaloo B & B](https://www.booking.com/hotel/au/mullaloo-b-amp-b.de.html?label=brave_brand_organic_trigger_8e04a9f7-c7d3-4b3b-a255-3644144f3921_0&sid=03f3572eadfa0a84123c1e30621c4c11&aid=2405329)
+
+![Unterkunft Bild](https://cf.bstatic.com/xdata/images/hotel/max1024x768/98616542.jpg?k=a1077c453d5de9046ad572abef1d1d7da9782ffb8977fa71cfebd25247af388d&o=)
+
+**Preis: AUD 718,24**
 
 ## 🚗 Transport
 
@@ -17,7 +21,7 @@ Perth ist autoorientiert, aber das öffentliche Verkehrssystem verbindet die Sta
 
 ## 📅 Aufenthaltsdauer
 
-_Wird noch ergänzt..._
+`25. September bis 3. Oktober`
 
 ---
 

--- a/japan/kyoto/index.md
+++ b/japan/kyoto/index.md
@@ -9,7 +9,11 @@ Kyoto, das kulturelle Herz Japans und ehemalige Hauptstadt, erwartet uns mit üb
 
 ## 🏨 Unterkunft
 
-_Wird noch ergänzt..._
+[Weekly Green In Namba](https://www.booking.com/hotel/jp/weekly-green-in-namba.de.html?label=brave_brand_organic_trigger_8e04a9f7-c7d3-4b3b-a255-3644144f3921_0&sid=03f3572eadfa0a84123c1e30621c4c11&aid=2405329)
+
+![Unterkunft Bild](https://images.trvl-media.com/lodging/50000000/49300000/49290700/49290682/c72eced9.jpg?impolicy=resizecrop&rw=575&rh=575&ra=fill)
+
+**Preis: ¥31.331**
 
 ## 🚗 Transport
 
@@ -17,7 +21,7 @@ Kyoto lässt sich hervorragend zu Fuß, mit dem Fahrrad oder dem effizienten Bus
 
 ## 📅 Aufenthaltsdauer
 
-_Wird noch ergänzt..._
+`30. August bis 4. September`
 
 ---
 

--- a/japan/osaka/index.md
+++ b/japan/osaka/index.md
@@ -9,7 +9,11 @@ Osaka, bekannt als "Tenka no Daidokoro" (die Küche des Landes), ist das kulinar
 
 ## 🏨 Unterkunft
 
-_Wird noch ergänzt..._
+[M's Hotel Kyoto Station Taruya](https://www.booking.com/hotel/jp/ms-inn-kyoto-station-taruya.de.html?label=brave_brand_organic_trigger_8e04a9f7-c7d3-4b3b-a255-3644144f3921_0&sid=03f3572eadfa0a84123c1e30621c4c11&aid=2405329#map_closed)
+
+![Unterkunft Bild](https://kyohotel.jp/wp-content/uploads/2019/11/91d7208dca6d17f393d0668bf84009dd-scaled.jpg)
+
+**Preis: ¥41.605**
 
 ## 🚗 Transport
 
@@ -17,7 +21,7 @@ Das Osaka Metro-System bringt uns schnell zu allen wichtigen Sehenswürdigkeiten
 
 ## 📅 Aufenthaltsdauer
 
-_Wird noch ergänzt..._
+`23. bis 30. August`
 
 ---
 

--- a/japan/tokyo/index.md
+++ b/japan/tokyo/index.md
@@ -9,7 +9,11 @@ Tokyo, eine Stadt der Kontraste und Superlative. Mit über 37 Millionen Einwohne
 
 ## 🏨 Unterkunft
 
-_Wird noch ergänzt..._
+[Sotetsu Fresa Inn Hamamatsucho-Daimon](https://www.booking.com/hotel/jp/sotetsu-fresa-inn-hamamatsucho-daimon.de.html?label=brave_brand_organic_trigger_8e04a9f7-c7d3-4b3b-a255-3644144f3921_0&sid=03f3572eadfa0a84123c1e30621c4c11&aid=2405329)
+
+![Unterkunft Bild](https://cf.bstatic.com/xdata/images/hotel/max1024x768/8108821.jpg?k=388141bafab70a249512c8534937ddd0816b6c9ee2e4e8eb8f9a0812ba3f8a10&o=)
+
+**Preis: ¥78.624**
 
 ## 🚇 Transport
 
@@ -17,7 +21,7 @@ Tokyo hat das komplexeste aber effizienteste Bahnsystem der Welt. Mit der JR Pas
 
 ## 📅 Aufenthaltsdauer
 
-_Wird noch ergänzt..._
+`15. bis 23. August`
 
 ---
 


### PR DESCRIPTION
This pull request adds detailed accommodation information and specific travel dates for four major city destinations in Australia and Japan. The updates enhance the travel guides by providing hotel recommendations with images, prices, and exact stay periods, replacing previous placeholders.

Accommodation details added:

* [`japan/tokyo/index.md`](diffhunk://#diff-1d17874bf698b8e54af2c3cbf3658f1fae7ff18488566f762ff8a562a3708457L12-R24): Included hotel name (`Sotetsu Fresa Inn Hamamatsucho-Daimon`), booking link, image, and price for Tokyo.
* [`japan/osaka/index.md`](diffhunk://#diff-b99653c25168b5f3999ed1a4f3ea25f2786f356ebfb4b33fe4c0ca6fe8478e0bL12-R24): Included hotel name (`M's Hotel Kyoto Station Taruya`), booking link, image, and price for Osaka.
* [`japan/kyoto/index.md`](diffhunk://#diff-917654b3d737f648c404656137618c251563b06f95c4560262f2ceca9ba22711L12-R24): Included hotel name (`Weekly Green In Namba`), booking link, image, and price for Kyoto.
* [`australien/perth/index.md`](diffhunk://#diff-752d33130c93d7dcd7dce4b06638ae54ea7c6e81fc082ba47cc5cee672192054L12-R24): Included hotel name (`Mullaloo B & B`), booking link, image, and price for Perth.

Travel dates specified:

* All four city guides now list the exact period of stay, replacing previous placeholders with concrete dates. [[1]](diffhunk://#diff-1d17874bf698b8e54af2c3cbf3658f1fae7ff18488566f762ff8a562a3708457L12-R24) [[2]](diffhunk://#diff-b99653c25168b5f3999ed1a4f3ea25f2786f356ebfb4b33fe4c0ca6fe8478e0bL12-R24) [[3]](diffhunk://#diff-917654b3d737f648c404656137618c251563b06f95c4560262f2ceca9ba22711L12-R24) [[4]](diffhunk://#diff-752d33130c93d7dcd7dce4b06638ae54ea7c6e81fc082ba47cc5cee672192054L12-R24)